### PR TITLE
Iterasi 5 | change logic in order controller for jmeter testing

### DIFF
--- a/app/Http/Controllers/API/Transactions/OrderController.php
+++ b/app/Http/Controllers/API/Transactions/OrderController.php
@@ -129,7 +129,15 @@ class OrderController extends BaseController
 
             // --- PERBAIKAN LOGIKA UTAMA ADA DI SINI ---
             $chargePayload = $this->prepareMidtransPayload($order, $paymentMethod, $user);
-            $midtransResponse = CoreApi::charge($chargePayload);
+            // $midtransResponse = CoreApi::charge($chargePayload);
+
+            //for jmeter testing -> comment $midtransResponse before
+            $midtransResponse = json_decode(
+                \Illuminate\Support\Facades\Http::post(
+                    url('/api/mock/charge'), // Panggil mock endpoint lokal
+                    $chargePayload
+                )->body()
+            );
 
             $this->createTransactionRecords($order, $midtransResponse, $paymentMethod->id);
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -45,7 +45,6 @@ Route::get('test', function () {
     dd('hello');
 });
 
-// Route::group(['middleware' => 'cors'], function () {
 Route::post('/register', [AuthController::class, 'register']);
 Route::post('/verify-otp', [AuthController::class, 'verifyOtp']);
 Route::post('/resend-otp', [AuthController::class, 'resendOtp']);
@@ -68,8 +67,25 @@ Route::prefix('carousels')
 
 Route::post('/webhooks/midtrans', [MidtransWebhookController::class, 'handle'])->name('webhooks.midtrans');
 
+//membuat sebuah endpoint di aplikasi Laravel Anda yang meniru respons sukses dari Midtrans secepat mungkin.
+Route::post('/mock/charge', function () {
+    // Endpoint ini meniru respons sukses dari Midtrans secepat mungkin.
+    // Tidak ada logika, hanya mengembalikan JSON.
+    return response()->json([
+        'transaction_id' => 'mock-tx-' . uniqid(),
+        'order_id' => request('transaction_details.order_id', 'mock-order-' . uniqid()),
+        'status_code' => '200',
+        'transaction_status' => 'pending',
+        'payment_type' => 'bank_transfer',
+        'gross_amount' => request('transaction_details.gross_amount', '100000.00'),
+        'va_numbers' => [
+            ['bank' => 'bca', 'va_number' => '1234567890']
+        ],
+        'expiry_time' => now()->addDay()->toDateTimeString(),
+    ]);
+});
+
 Route::get('/debug-permissions', function () {
-    // Pastikan Anda mengirim token Bearer di header saat memanggil endpoint ini
     if (Auth::check()) {
         $user = Auth::user();
         return response()->json([


### PR DESCRIPTION
// UBAH DARI:
// $midtransResponse = CoreApi::charge($chargePayload);

// MENJADI (untuk sementara saat performance test):
$midtransResponse = json_decode(
    \Illuminate\Support\Facades\Http::post(
        url('/api/mock/charge'), // Panggil mock endpoint lokal
        $chargePayload
    )->body()
);